### PR TITLE
Add support for defining required actions on new user accounts

### DIFF
--- a/src/keycloak/user.go
+++ b/src/keycloak/user.go
@@ -9,6 +9,7 @@ type User struct {
 	FirstName string `json:"firstName,omitempty"`
 	LastName string `json:"lastName,omitempty"`
 	Email string `json:"email"`
+	RequiredActions []string `json:"requiredActions,omitempty"`
 }
 
 const (

--- a/test/main.tf
+++ b/test/main.tf
@@ -8,63 +8,67 @@ resource "keycloak_client" "client_test" {
 */
 
 resource "keycloak_group" "group1" {
-  name       = "group1"
-  realm      = "Jenkins"
+  name  = "group1"
+  realm = "Jenkins"
 }
 
 resource "keycloak_group" "group2" {
-  name       = "group2"
-  realm      = "Jenkins"
+  name  = "group2"
+  realm = "Jenkins"
 }
 
 resource "keycloak_group" "group11" {
-  name       = "group11"
-  realm      = "Jenkins"
+  name  = "group11"
+  realm = "Jenkins"
 }
+
 resource "keycloak_group" "group21" {
-  name       = "group21"
-  realm      = "Jenkins"
+  name  = "group21"
+  realm = "Jenkins"
 }
+
 resource "keycloak_user" "martin" {
-  realm      = "Jenkins"
-  username   = "martin"
-  firstname  = "Martin"
-  lastname   = "Patel"
-  email      = "mpatel@abc.com"
+  realm     = "Jenkins"
+  username  = "martin"
+  firstname = "Martin"
+  lastname  = "Patel"
+  email     = "mpatel@abc.com"
 }
+
 resource "keycloak_user" "martin1" {
-  realm      = "Jenkins"
-  username   = "martin1"
-  firstname  = "martin1"
-  lastname   = "patel"
-  email      = "mpatel1@abc.com"
+  realm     = "Jenkins"
+  username  = "martin1"
+  firstname = "martin1"
+  lastname  = "patel"
+  email     = "mpatel1@abc.com"
 }
 
 resource "keycloak_user" "josh" {
-  realm      = "Jenkins"
-  username   = "josh"
-  firstname  = "josh"
-  lastname   = "cameron"
-  email      = "jcameron@abc.com"
+  realm     = "Jenkins"
+  username  = "josh"
+  firstname = "josh"
+  lastname  = "cameron"
+  email     = "jcameron@abc.com"
 }
 
 resource "keycloak_user" "josh1" {
-  realm      = "Jenkins"
-  username   = "josh1"
-  firstname  = "josh"
-  lastname   = "cameron"
-  email      = "jcameron1@abc.com"
+  realm     = "Jenkins"
+  username  = "josh1"
+  firstname = "josh"
+  lastname  = "cameron"
+  email     = "jcameron1@abc.com"
+
   initial_required_actions = ["UPDATE_PASSWORD"]
 }
 
 resource "keycloak_user_group_mapping" "group1_map" {
   group_id = "${keycloak_group.group1.id}"
-  user_ids   = ["${keycloak_user.martin1.id}", ]
-  realm      = "Jenkins"
+  user_ids = ["${keycloak_user.martin1.id}"]
+  realm    = "Jenkins"
 }
 
 resource "keycloak_user_group_mapping" "group2_map" {
   group_id = "${keycloak_group.group2.id}"
-  user_ids   = ["${keycloak_user.josh1.id}"]
-  realm      = "Jenkins"
+  user_ids = ["${keycloak_user.josh1.id}"]
+  realm    = "Jenkins"
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -54,6 +54,7 @@ resource "keycloak_user" "josh1" {
   firstname  = "josh"
   lastname   = "cameron"
   email      = "jcameron1@abc.com"
+  initial_required_actions = ["UPDATE_PASSWORD"]
 }
 
 resource "keycloak_user_group_mapping" "group1_map" {


### PR DESCRIPTION
These changes adds the ability to configure an optional list of required actions an user has to perform when signing in. This can be configuring OTP, verifying email etc.

It has been created to only set required actions for user accounts scheduled to be created, meaning setting required actions on existing accounts won't have any effect.

Any thoughts?