### PR TITLE
feat: add support for client roles with composite role references

### DIFF
--- a/src/keycloak/role.go
+++ b/src/keycloak/role.go
@@ -1,0 +1,90 @@
+package keycloak
+
+import "fmt"
+
+type RoleRepresentation struct {
+	Id             string  `json:"id"`
+	Description    string  `json:"description"`
+	Name           string  `json:"name"`
+}
+
+type CompositeRoleReference struct {
+	Id             string  `json:"id"`
+}
+
+const (
+	clientRolesUri  = "%s/auth/admin/realms/%s/clients/%s/roles"
+	clientRoleUri   = "%s/auth/admin/realms/%s/clients/%s/roles/%s"
+	clientRolesCompositesUri = "%s/auth/admin/realms/%s/clients/%s/roles/%s/composites"
+)
+
+func (c *KeycloakClient) GetClientRole(clientId string, realm string, representation *RoleRepresentation) (*RoleRepresentation, error) {
+	var role RoleRepresentation
+	roleUrl := fmt.Sprintf(clientRoleUri, c.url, realm, clientId, representation.Name)
+	err := c.get(roleUrl, &role)
+	return &role, err
+}
+
+func (c *KeycloakClient) CreateClientRole(clientId string, realm string, representation *RoleRepresentation) (*RoleRepresentation, error) {
+	url := fmt.Sprintf(clientRolesUri, c.url, realm, clientId)
+
+
+	_, err := c.post(url, representation)
+	if err != nil {
+		return nil, err
+	}
+
+	var createdRole RoleRepresentation
+	roleUrl := fmt.Sprintf(clientRoleUri, c.url, realm, clientId, representation.Name)
+	err = c.get(roleUrl, &createdRole)
+
+	return &createdRole, err
+}
+
+func (c *KeycloakClient) UpdateClientRole(clientId string, realm string, representation *RoleRepresentation) error {
+	url := fmt.Sprintf(clientRoleUri, c.url, realm, clientId, representation.Name)
+	err := c.put(url, representation)
+	return err
+}
+
+func (c *KeycloakClient) DeleteClientRole(clientId string, realm string, representation *RoleRepresentation) error {
+	url := fmt.Sprintf(clientRoleUri, c.url, realm, clientId, representation.Name)
+	err := c.delete(url, representation)
+	return err
+}
+
+func (c *KeycloakClient) GetCompositeRoles(clientId string, realm string, representation *RoleRepresentation) ([]string, error) {
+	var roles []CompositeRoleReference
+	roleUrl := fmt.Sprintf(clientRolesCompositesUri, c.url, realm, clientId, representation.Name)
+	err := c.get(roleUrl, &roles)
+	
+	var compositeRoleIds []string
+	for _, value := range roles {
+		compositeRoleIds = append(compositeRoleIds, value.Id)
+	}
+	
+	return compositeRoleIds, err
+}
+
+func (c *KeycloakClient) AddRolesToCompositeRole(clientId string, realm string, representation *RoleRepresentation, roleIds []string) error {
+	url := fmt.Sprintf(clientRolesCompositesUri, c.url, realm, clientId, representation.Name)
+	_, err := c.post(url, toCompositeRoleRepresentation(roleIds))
+	return err
+}
+
+func (c *KeycloakClient) RemoveRolesFromCompositeRole(clientId string, realm string, representation *RoleRepresentation, roleIds []string) error {
+	url := fmt.Sprintf(clientRolesCompositesUri, c.url, realm, clientId, representation.Name)
+	err := c.delete(url, toCompositeRoleRepresentation(roleIds))
+	return err
+}
+
+func toCompositeRoleRepresentation(roleIds []string) []*CompositeRoleReference {
+	var roles []*CompositeRoleReference
+	for _, value := range roleIds {
+		role := CompositeRoleReference{
+			Id: value,
+		}
+		roles = append(roles, &role)
+	}
+	return roles
+}

--- a/src/keycloak/role.go
+++ b/src/keycloak/role.go
@@ -3,31 +3,30 @@ package keycloak
 import "fmt"
 
 type RoleRepresentation struct {
-	Id             string  `json:"id"`
-	Description    string  `json:"description"`
-	Name           string  `json:"name"`
+	Id          string `json:"id"`
+	Description string `json:"description"`
+	Name        string `json:"name"`
 }
 
 type CompositeRoleReference struct {
-	Id             string  `json:"id"`
+	Id string `json:"id"`
 }
 
 const (
-	clientRolesUri  = "%s/auth/admin/realms/%s/clients/%s/roles"
-	clientRoleUri   = "%s/auth/admin/realms/%s/clients/%s/roles/%s"
+	clientRolesUri           = "%s/auth/admin/realms/%s/clients/%s/roles"
+	clientRoleUri            = "%s/auth/admin/realms/%s/clients/%s/roles/%s"
 	clientRolesCompositesUri = "%s/auth/admin/realms/%s/clients/%s/roles/%s/composites"
 )
 
-func (c *KeycloakClient) GetClientRole(clientId string, realm string, representation *RoleRepresentation) (*RoleRepresentation, error) {
+func (c *KeycloakClient) GetClientRole(clientId string, realm string, roleName string) (*RoleRepresentation, error) {
 	var role RoleRepresentation
-	roleUrl := fmt.Sprintf(clientRoleUri, c.url, realm, clientId, representation.Name)
+	roleUrl := fmt.Sprintf(clientRoleUri, c.url, realm, clientId, roleName)
 	err := c.get(roleUrl, &role)
 	return &role, err
 }
 
 func (c *KeycloakClient) CreateClientRole(clientId string, realm string, representation *RoleRepresentation) (*RoleRepresentation, error) {
 	url := fmt.Sprintf(clientRolesUri, c.url, realm, clientId)
-
 
 	_, err := c.post(url, representation)
 	if err != nil {
@@ -57,12 +56,12 @@ func (c *KeycloakClient) GetCompositeRoles(clientId string, realm string, repres
 	var roles []CompositeRoleReference
 	roleUrl := fmt.Sprintf(clientRolesCompositesUri, c.url, realm, clientId, representation.Name)
 	err := c.get(roleUrl, &roles)
-	
+
 	var compositeRoleIds []string
 	for _, value := range roles {
 		compositeRoleIds = append(compositeRoleIds, value.Id)
 	}
-	
+
 	return compositeRoleIds, err
 }
 

--- a/src/keycloak/user.go
+++ b/src/keycloak/user.go
@@ -3,17 +3,17 @@ package keycloak
 import "fmt"
 
 type User struct {
-	Id string `json:"id"`
-	Username string `json:"username"`
-	Enabled bool `json:"enabled"`
+	Id        string `json:"id"`
+	Username  string `json:"username"`
+	Enabled   bool   `json:"enabled"`
 	FirstName string `json:"firstName,omitempty"`
-	LastName string `json:"lastName,omitempty"`
-	Email string `json:"email"`
+	LastName  string `json:"lastName,omitempty"`
+	Email     string `json:"email"`
 }
 
 const (
-	userUri          = "%s/auth/admin/realms/%s/users/%s"
-	userList          = "%s/auth/admin/realms/%s/users"
+	userUri  = "%s/auth/admin/realms/%s/users/%s"
+	userList = "%s/auth/admin/realms/%s/users"
 )
 
 func (c *KeycloakClient) AddUser(user *User, realm string) (*User, error) {
@@ -29,7 +29,6 @@ func (c *KeycloakClient) AddUser(user *User, realm string) (*User, error) {
 	return &createdUser, err
 }
 
-
 // Attempt to look up user by given user ID
 func (c *KeycloakClient) GetUser(userId string, realm string) (*User, error) {
 	url := fmt.Sprintf(userUri, c.url, realm, userId)
@@ -40,9 +39,8 @@ func (c *KeycloakClient) GetUser(userId string, realm string) (*User, error) {
 	return &user, err
 }
 
-
 // Attempt to update user
-func (c *KeycloakClient) UpdateUser(user *User, realm string) (error) {
+func (c *KeycloakClient) UpdateUser(user *User, realm string) error {
 	url := fmt.Sprintf(userUri, c.url, realm, user.Id)
 	err := c.put(url, *user)
 
@@ -52,7 +50,6 @@ func (c *KeycloakClient) UpdateUser(user *User, realm string) (error) {
 
 	return nil
 }
-
 
 func (c *KeycloakClient) DeleteUser(id string, realm string) error {
 	url := fmt.Sprintf(userUri, c.url, realm, id)

--- a/src/provider/provider.go
+++ b/src/provider/provider.go
@@ -13,6 +13,7 @@ func Provider() terraform.ResourceProvider {
 		ConfigureFunc: schema.ConfigureFunc(keycloakProviderSetup),
 		ResourcesMap: map[string]*schema.Resource{
 			"keycloak_client":             resourceClient(),
+			"keycloak_client_role":        resourceClientRole(),
 			"keycloak_user_role_mapping":  resourceUserRoleMapping(),
 			"keycloak_realm":              resourceRealm(),
 			"keycloak_user":               resourceUser(),

--- a/src/provider/resource_client_role.go
+++ b/src/provider/resource_client_role.go
@@ -1,0 +1,191 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"keycloak"
+	"log"
+)
+
+func resourceClientRole() *schema.Resource {
+	return &schema.Resource{
+		// API methods
+		Read:   schema.ReadFunc(resourceClientRoleRead),
+		Create: schema.CreateFunc(resourceClientRoleCreate),
+		Update: schema.UpdateFunc(resourceClientRoleUpdate),
+		Delete: schema.DeleteFunc(resourceClientRoleDelete),
+
+		// Keycloak clients are importable by ID, but the realm must also be provided by the user.
+		Importer: &schema.ResourceImporter{
+			State: importClientHelper,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"realm": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"client_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"composite_role_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceDataToRoleRepresentation(d *schema.ResourceData) *keycloak.RoleRepresentation {
+	c := keycloak.RoleRepresentation {
+		Name:                d.Get("name").(string),
+		Description: 		 d.Get("description").(string),
+	}
+
+	if !d.IsNewResource() {
+		c.Id = d.Id()
+	}
+
+	return &c
+}
+
+func resourceClientRoleRead(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*keycloak.KeycloakClient)
+	d.Partial(true)
+	readRole, err := apiClient.GetClientRole(clientId(d), realm(d), resourceDataToRoleRepresentation(d))
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", readRole.Name)
+	d.Set("description", readRole.Description)
+	d.SetId(readRole.Id)
+
+	roleIds := getCompositeRoleIds(d)
+	if len(roleIds) > 0 {
+		compositeRoleIds, err := apiClient.GetCompositeRoles(clientId(d), realm(d), resourceDataToRoleRepresentation(d))
+		if err != nil {
+			return err
+		}
+
+		setCompositeRoleIds(compositeRoleIds, d)
+	}
+	d.Partial(false)
+	return nil
+}
+
+func resourceClientRoleCreate(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*keycloak.KeycloakClient)
+	d.Partial(true)
+	createdRole, err := apiClient.CreateClientRole(clientId(d), realm(d), resourceDataToRoleRepresentation(d))
+	if err != nil {
+		log.Printf("[WARN] Error when creating client role: %s", err.Error())
+		return err
+	}
+
+	d.Set("name", createdRole.Name)
+	d.Set("description", createdRole.Description)
+	d.SetId(createdRole.Id)
+
+	roleIds := getCompositeRoleIds(d)
+	if len(roleIds) > 0 {
+		err = apiClient.AddRolesToCompositeRole(
+			clientId(d), realm(d), resourceDataToRoleRepresentation(d), roleIds)
+		if err != nil {
+			log.Printf("[WARN] Error when adding composite roles: %s", err.Error())
+			return err
+		}
+
+		compositeRoleIds, err := apiClient.GetCompositeRoles(clientId(d), realm(d), resourceDataToRoleRepresentation(d))
+		if err != nil {
+			log.Printf("[WARN] Error when fetching composite roles: %s", err.Error())
+			return err
+		}
+
+		setCompositeRoleIds(compositeRoleIds, d)
+	}
+
+	d.Partial(false)
+	return nil
+}
+
+func resourceClientRoleUpdate(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*keycloak.KeycloakClient)
+	log.Printf("[WARN] Updating keycloak client role")
+	d.Partial(true)
+	err := apiClient.UpdateClientRole(clientId(d), realm(d), resourceDataToRoleRepresentation(d))
+	if err != nil {
+		return err
+	}
+
+	currentRoles, err := apiClient.GetCompositeRoles(clientId(d), realm(d), resourceDataToRoleRepresentation(d))
+	if err != nil {
+		return err
+	}
+
+	desiredRoles := getCompositeRoleIds(d)
+
+	var rolesToAdd []string
+	for _, desiredRole := range desiredRoles {
+		if !contains(currentRoles, desiredRole) {
+			rolesToAdd = append(rolesToAdd, desiredRole)
+		}
+	}
+
+	var rolesToRemove []string
+	for _, currentRole := range currentRoles {
+		if !contains(desiredRoles, currentRole) {
+			rolesToRemove = append(rolesToRemove, currentRole)
+		}
+	}
+
+	if len(rolesToAdd) > 0 {
+		err = apiClient.AddRolesToCompositeRole(clientId(d), realm(d), resourceDataToRoleRepresentation(d), rolesToAdd)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(rolesToRemove) > 0 {
+		err = apiClient.RemoveRolesFromCompositeRole(clientId(d), realm(d), resourceDataToRoleRepresentation(d), rolesToRemove)
+		if err != nil {
+			return err
+		}
+	}
+
+	currentRoles, err = apiClient.GetCompositeRoles(clientId(d), realm(d), resourceDataToRoleRepresentation(d))
+	if err != nil {
+		return err
+	}
+
+	setCompositeRoleIds(currentRoles, d)
+	d.Partial(false)
+	return nil
+}
+
+func resourceClientRoleDelete(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*keycloak.KeycloakClient)
+	return apiClient.DeleteClientRole(clientId(d), realm(d), resourceDataToRoleRepresentation(d))
+}
+
+func getCompositeRoleIds(d *schema.ResourceData) []string {
+	return getStringSlice(d, "composite_role_ids")
+}
+
+// This method avoids setting the role_ids if they contain the same elements
+// This is to avoid reordering based on sorting / retrieval method after updating / changes
+func setCompositeRoleIds(currentRoleIds []string, d *schema.ResourceData) {
+	storedRoleIds := getStringSlice(d, "composite_role_ids")
+	if !containsSameElements(currentRoleIds, storedRoleIds) {
+		d.Set("composite_role_ids", currentRoleIds)
+	}
+}

--- a/src/provider/util.go
+++ b/src/provider/util.go
@@ -11,6 +11,32 @@ func realm(d *schema.ResourceData) string {
 	return d.Get("realm").(string)
 }
 
+func clientId(d *schema.ResourceData) string {
+	return d.Get("client_id").(string)
+}
+
+func containsSameElements(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for _, a_elem := range a {
+		if !contains(b, a_elem) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
 func getOptionalBool(d *schema.ResourceData, key string) *bool {
 	if v, present := d.GetOk(key); present {
 		b := v.(bool)


### PR DESCRIPTION
This adds support for defining client roles, with optional support for making it a composite role, consisting of other roles.

As an example terraform configuration:

```

resource "keycloak_client_role" "my-awesome-role" {
  realm = "${keycloak_realm.my-realm.id}"
  client_id = "${keycloak_client.my-awesome-api.id}"
  name = "AWESOME_ROLE"
}

resource "keycloak_client_role" "another-role" {
  realm = "${keycloak_realm.my-realm.id}"
  client_id = "${keycloak_client.my-awesome-api.id}"
  name = "ANOTHER_ROLE"
}

resource "keycloak_client_role" "my-composite-role" {
  realm = "${keycloak_realm.my-realm.id}"
  client_id = "${keycloak_client.my-awesome-api.id}"
  name = "MyCompositeRole"
  composite_role_ids = [
    "${keycloak_client_role.my-awesome-role.id}",
    "${keycloak_client_role.another-role.id}"
  ]
}

resource "keycloak_user_role_mapping" "another-api-has-" {
  realm     = "${keycloak_realm.my-realm.id}"
  name   = "${keycloak_client_role.my-composite-role.name}"
  user_id = "${keycloak_client.another-api.service_account_user_id}"
}
```

Testing performed, in sequence:

1. Add a role `role_1` without composite roles
2. Add a role `role_2` without composite roles
3. Add a role `role_3` with composte role on the `role_1` and `role_2`
4. Remove 1/2 composite roles on `role_3`
5. Add back `role_2` for `role_3`
6. Reorder roles (No changes detected, since we are comparing that same elements exist in code before updating TF state)
7. Remove composite role `role_3`
8. Add composite role `role_4`, with `role_1` and `role_2`
9. Remove both composite roles from `role_4` -> Observing that it is no longer a composite role in Keycloak
10. Remove `role_2`
11. Remove `role_1`

All was cleaned up fine.

Final testcase:

1. Define the following in terraform:
- Role 1
- Role 2
- Role 3, composite of 1 and 2
- Define `keycloak_user_role_mapping` towards Role 3

2. Verify that all roles are created in correct order, and that user is assigned the desired role

This is now working when https://github.com/tazjin/terraform-provider-keycloak/pull/34 is merged successfully. Together I have tested all these steps successfully. 

@phillipj @mahpatil 