### PR TITLE
Add support to manage custom "attributes" on user resources

### DIFF
--- a/keycloak/user.go
+++ b/keycloak/user.go
@@ -10,6 +10,12 @@ type User struct {
 	LastName        string   `json:"lastName,omitempty"`
 	Email           string   `json:"email"`
 	RequiredActions []string `json:"requiredActions,omitempty"`
+
+	// Keycloak models these attributes as a map where the value is a string slice,
+	// although the can only be one string value per map item. The REST API docs
+	// aren't very clear about this either, this knowledge is only based on looking
+	// at the actual API responses.
+	Attributes map[string][]string `json:"attributes,omitempty"`
 }
 
 const (

--- a/test/main.tf
+++ b/test/main.tf
@@ -49,6 +49,10 @@ resource "keycloak_user" "josh" {
   firstname = "josh"
   lastname  = "cameron"
   email     = "jcameron@abc.com"
+
+  attributes = {
+    customMetaData = "josh rocks"
+  }
 }
 
 resource "keycloak_user" "josh1" {


### PR DESCRIPTION
As described in [Keycloak's REST API docs](https://www.keycloak.org/docs-api/4.0/rest-api/index.html#_userrepresentation), user "attributes" allows any kind of metadata to be persisted on user accounts.

We use this internally to put non-standard values into JWTs when needed.

/cc @jorgeng