### PR TITLE
Build and upload release binaries with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,26 @@ go:
   - 1.11
 env:
   - GO111MODULE=on
+
+before_install:
+  # gox simplifies building for multiple architectures
+  - go get github.com/mitchellh/gox
+
 script:
   - go vet ./...
   - (! go fmt ./... 2>&1 | read) || (echo "Code is not properly formatted, remember to use gofmt on all new changes." && exit 1)
+  - gox -os="linux darwin freebsd windows" -arch="amd64" -output="releases/terraform-provider-keycloak-${TRAVIS_TAG}-{{.OS}}-{{.Arch}}"
+
+deploy:
+  provider: releases
+  skip_cleanup: true
+  # Explicitly set release title on GitHub
+  name: $TRAVIS_TAG
+  api_key:
+    secure: "WxWlE+Vf6XeSsx+uwXNk+4eblpin74h9yLtW4z7siyjhaO3UqJQSRyAcBj/jC27+82FN1EzoU0muNbgaZtVYaWDQaaNHzFuhcYbzimxb2TzOaF75vUEebHuUC1EQ5yOn1anSdQN8vXqvVM36YyO3VwMJh3gUHOnv3FIpFBoG+y97nQ7JabvJx/ZrxurKgbYkLA5JlldlKLb1RqhNxBoirmORw3gH5M+mb+Y/Pu1pVUQtCA2bEtkUDZx/dQx7h+bUPk2d5AhPRqGBXMYT9h/gGx9clow9Twv8jRBoL4pxesn0XmCySmdFp8nItbtCRWE2bZCnwxOMp5aVBtODWFghvbJVhalUU4kAGAujawqm9sp81fvTJZvGuPKVrRc1TUSYIoRLxUCjKV7rK93qbt6CMOLLOvv8GQ3a0DPRkDqAbnSo4r4GL+9SSvFgEkCPLstGWIp/P9K9LplEbXElrxdM7UNpyZMa2gVpeZ7Dr+lymqpO0bxLI2D3JggPMeSS0coKUbgibZHnNcRCjRTKdHxLZvOsqgqQ/881cmRTMQdrKuEC9PlOCJ3ZxhkoeaYqcsPw/aRyTnV+vT+Mrw51aQ07wH47hkT9By2hEeNnw79QCOq93jNBbwWosKeithmtN4S7J5ClUNJ2Cq7DQyZ4zNAGTyyQQGQZvznELAbQfX3QiKM="
+  file_glob: true
+  file: releases/*
+  on:
+    repo: tazjin/terraform-provider-keycloak
+    # Only build binaries for tagged commits
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ deploy:
   # Explicitly set release title on GitHub
   name: $TRAVIS_TAG
   api_key:
+    # This is an encrypted personal OAuth GitHub token, encrypted with the Travis CI CLI. If the OAuth token gets revoked
+    # for whatever reason, a new personal OAuth token has to be created by a maintainer, with the public_repo or repo scope,
+    # encrypted via the `travis encrypt` command and the value below updated
     secure: "WxWlE+Vf6XeSsx+uwXNk+4eblpin74h9yLtW4z7siyjhaO3UqJQSRyAcBj/jC27+82FN1EzoU0muNbgaZtVYaWDQaaNHzFuhcYbzimxb2TzOaF75vUEebHuUC1EQ5yOn1anSdQN8vXqvVM36YyO3VwMJh3gUHOnv3FIpFBoG+y97nQ7JabvJx/ZrxurKgbYkLA5JlldlKLb1RqhNxBoirmORw3gH5M+mb+Y/Pu1pVUQtCA2bEtkUDZx/dQx7h+bUPk2d5AhPRqGBXMYT9h/gGx9clow9Twv8jRBoL4pxesn0XmCySmdFp8nItbtCRWE2bZCnwxOMp5aVBtODWFghvbJVhalUU4kAGAujawqm9sp81fvTJZvGuPKVrRc1TUSYIoRLxUCjKV7rK93qbt6CMOLLOvv8GQ3a0DPRkDqAbnSo4r4GL+9SSvFgEkCPLstGWIp/P9K9LplEbXElrxdM7UNpyZMa2gVpeZ7Dr+lymqpO0bxLI2D3JggPMeSS0coKUbgibZHnNcRCjRTKdHxLZvOsqgqQ/881cmRTMQdrKuEC9PlOCJ3ZxhkoeaYqcsPw/aRyTnV+vT+Mrw51aQ07wH47hkT9By2hEeNnw79QCOq93jNBbwWosKeithmtN4S7J5ClUNJ2Cq7DQyZ4zNAGTyyQQGQZvznELAbQfX3QiKM="
   file_glob: true
   file: releases/*

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ $ git push origin --tags
 ```
 
 The above will make Travis CI build the project as usual, then upload the resulting binaries
-up to github.com, making them visible on our [releases][] page.
+up to github.com, making them visible on our [releases][] page. Maintainer publishing the new
+release has to manually fill in the release body of that given version, with details about
+what changes got introduced.
 
 [Terraform provider]: https://www.terraform.io/docs/plugins/provider.html
 [Keycloak]: http://www.keycloak.org/

--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ files and `terraform providers` to check that it has been loaded correctly.
 
 **Note**: The targeted version of Terraform is currently **v0.11.11**.
 
-## Building from source
-
-For "vanilla"-builds just do this:
-
-1. Install and configure Go
-2. `make install`
-
 ## Setup instructions
 
 The Keycloak instance to manage needs to be configured with a client that has
@@ -89,6 +82,30 @@ To import a user or group use the following command:
 terraform import <keycloak_resource>.<resource_name> <realm_name>.<resource_id>
 terraform import keycloak_group.group2 Jenkins.310f73af-3b70-4e4a-9a6f-a3f4de8c8f
 ```
+
+## Building from source
+
+For "vanilla"-builds do this:
+
+1. Install and configure Go v1.11.x or later
+2. `$ make install`
+
+The last step will build the provider for your machine and copy the binary into `~/.terraform.d/plugins` ready to be used.
+
+## Publish new releases
+
+All maintainers have the ability to publish new releases of this provider
+by pushing a new git tag to the repository after new changes has been merged.
+
+As an example for publishing a new releases named `v1.0.1`:
+
+```
+$ git tag v1.0.1
+$ git push origin --tags
+```
+
+The above will make Travis CI build the project as usual, then upload the resulting binaries
+up to github.com, making them visible on our [releases][] page.
 
 [Terraform provider]: https://www.terraform.io/docs/plugins/provider.html
 [Keycloak]: http://www.keycloak.org/


### PR DESCRIPTION
These changes makes use of Travis CI to build binaries for linux, darwin, freebsd and windows, and upload those to github.com whenever new git tags are pushed.

The intention of doing is to lower the barrier for cutting new releases and ensuring the resulting binaries aren't dependant on how we as developers has setup our machines.

In practise this means that when we want to publish a new release of this terraform provider, after all commits has been landed in the master branch, a new git tag has to be created and pushed as well:

```
$ git tag v1.0.0
$ git push origin --tags
```

That should make Travis CI build the project as usual, and finish off by uploading the successfully built binaries to github.com, making them visible as an "asset" on the [Releases page](https://github.com/tazjin/terraform-provider-keycloak/releases).

Inspirational credits to: https://blog.questionable.services/article/build-go-binaries-travis-ci-github/
Travis CI docs: https://docs.travis-ci.com/user/deployment/releases

Closes https://github.com/tazjin/terraform-provider-keycloak/issues/35

/cc @jorgeng